### PR TITLE
fix: expo sdk 46 doctor error

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -37,7 +37,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config-plugins": "^4.1.0"
+    "@expo/config-plugins": "^5.0.0"
   },
   "devDependencies": {
     "expo-module-scripts": "^2.0.0"


### PR DESCRIPTION
There are some issue when using @braze/expo-plugin in expo sdk 46 (and maybe 45 too)
just dependencies update :)