### PR TITLE
🐛 (Android): Enable deeplink for android devices

### DIFF
--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -13,4 +13,5 @@ export type ConfigProps = {
   enableBrazeIosPush?: boolean;
   enableFirebaseCloudMessaging?: boolean;
   firebaseCloudMessagingSenderId?: string;
+  enablingAutomaticDeepLinkOpening?: string;
 };

--- a/plugin/src/withBrazeAndroid.ts
+++ b/plugin/src/withBrazeAndroid.ts
@@ -44,6 +44,7 @@ const ANDROID_CONFIG_MAP = {
   "enableAutomaticLocationCollection": ["com_braze_enable_location_collection", BX_BOOL],
   "enableAutomaticGeofenceRequests": ["com_braze_automatic_geofence_requests_enabled", BX_BOOL],
   "enableFirebaseCloudMessaging": ["com_braze_firebase_cloud_messaging_registration_enabled", BX_BOOL],
+  "enablingAutomaticDeepLinkOpening": ["com_braze_handle_push_deep_links_automatically", BX_BOOL],
 };
 
 async function appendContentsFromFile(config: any, tag: string, srcFile: string) {


### PR DESCRIPTION
Hello, 

For our project, on Android devices, we cant open the app when press on the push notification. You can find the reason in the documentation :

https://www.braze.com/docs/developer_guide/platform_integration_guides/android/push_notifications/android/troubleshooting#tapping-push-notification-doesnt-open-the-app

So we need to add this through the plugin in the Braze.xml

Thank you
