### PR TITLE
Fix null initial deep linking url

### DIFF
--- a/plugin/ios/ExpoAdapterBraze/BrazeAppDelegate.swift
+++ b/plugin/ios/ExpoAdapterBraze/BrazeAppDelegate.swift
@@ -67,6 +67,9 @@ public class BrazeAppDelegate: ExpoAppDelegateSubscriber {
       }
 
       configuration.api.addSDKMetadata([.expo])
+
+      BrazeReactUtils.sharedInstance().populateInitialUrl(fromLaunchOptions: launchOptions)
+
       let braze = BrazeReactBridge.perform(#selector(BrazeReactBridge.initBraze(_:)), with: configuration).takeUnretainedValue() as! Braze
       BrazeAppDelegate.braze = braze
 


### PR DESCRIPTION

Addresses the issue: [[Bug]: Deeplinks not working with push notification on iOS when app is closed](https://github.com/braze-inc/braze-expo-plugin/issues/15).

Feel free to close the issue if there's another better solution.