### PR TITLE
Fix build.grade for Expo SDK 50

### DIFF
--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -23,13 +23,16 @@ buildscript {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   defaultConfig {


### PR DESCRIPTION
This PR fixes a build error caused by the build complaining about there being a mismatch between Java 17 (required by Expo SDK 50) and Java 11 (required by this config-plugin)

The fix follows the same approach commonly used by Expos own modules 
For example https://github.com/expo/expo/blob/8a9b0c33dad957fb136f848dcf267dcb7539be0a/packages/expo-maps/android/build.gradle#L68-L78