### PR TITLE
add useUUIDAsDeviceId configuration option

### DIFF
--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -18,4 +18,5 @@ export type ConfigProps = {
   enableFirebaseCloudMessaging?: boolean;
   firebaseCloudMessagingSenderId?: string;
   androidHandlePushDeepLinksAutomatically?: boolean;
+  useUUIDAsDeviceId?: boolean;
 };

--- a/plugin/src/withBrazeiOS.ts
+++ b/plugin/src/withBrazeiOS.ts
@@ -75,6 +75,10 @@ const withBrazeInfoPlist: ConfigPlugin<ConfigProps> = (config, props) => {
       if (props.iosPushStoryAppGroup != null) {
         config.modResults.Braze.BrazePushStoryAppGroup = props.iosPushStoryAppGroup;
       }
+
+      if (props.useUUIDAsDeviceId != null) {
+        config.modResults.Braze.UseUUIDAsDeviceId = props.useUUIDAsDeviceId;
+      }
     }
 
     return config;


### PR DESCRIPTION
Adds a `useUUIDAsDeviceId` boolean configuration option that if set to `false`, forces Braze to use IDFV for device id instead of a random UUID.

Related Issue: https://github.com/braze-inc/braze-expo-plugin/issues/34