### PR TITLE
feat: add forwardUniversalLinks configuration option

### DIFF
--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -19,4 +19,5 @@ export type ConfigProps = {
   firebaseCloudMessagingSenderId?: string;
   androidHandlePushDeepLinksAutomatically?: boolean;
   iosUseUUIDAsDeviceId?: boolean;
+  forwardUniversalLinks?: boolean;
 };

--- a/plugin/src/withBrazeiOS.ts
+++ b/plugin/src/withBrazeiOS.ts
@@ -79,6 +79,10 @@ const withBrazeInfoPlist: ConfigPlugin<ConfigProps> = (config, props) => {
       if (props.iosUseUUIDAsDeviceId != null) {
         config.modResults.Braze.UseUUIDAsDeviceId = props.iosUseUUIDAsDeviceId;
       }
+
+      if (props.forwardUniversalLinks != null) {
+        config.modResults.Braze.ForwardUniversalLinks = props.forwardUniversalLinks;
+      }
     }
 
     return config;


### PR DESCRIPTION
Add support for configuring the `forwardUniversalLinks` property on iOS. 

See https://www.braze.com/docs/developer_guide/content_cards/deep_linking/?sdktab=swift#swift_universal-links