### PR TITLE
Release version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# 3.2.0
+## 4.0.0
+
+##### Breaking 
+- This version requires [`19.0.0`](https://github.com/braze-inc/braze-react-native-sdk/releases/tag/19.0.0) of the Braze React Native SDK.
+  - (Android) Fixed a memory leak in the data persistence layer.
+  - (Android) Adds support for Braze.getInitialPushPayload() to handle push notification deep links when the app is launched from a terminated state. This resolves an issue where deep links from push notifications were not handled on Android when the app was cold started.
+
+##### Fixed
+- Fixes the `enableAutomaticGeofenceRequests` configuration on iOS to be assigned to the correct property.
+  - Previously, this `app.json` configuration would be ignored and only enabled when `enableAutomaticLocationCollection` was `true`.
+
+## 3.2.0
 
 ##### Added
 - Updates the sample app to use [Expo SDK 54](https://expo.dev/changelog/sdk-54).
@@ -6,14 +17,14 @@
 - Adds the `forwardUniversalLinks` option (default: `false`) to configure the native Swift SDK handling of universal links. See [`forwardUniversalLinks`](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/configuration-swift.class/forwarduniversallinks).
   - This value determines whether the SDK will automatically recognize and forward universal links to the system methods.
 
-# 3.1.0
+## 3.1.0
 
 ##### Added
 - Adds the `iosUseUUIDAsDeviceId` option (default: `true`) to configure the native Swift SDK's device ID. See [`useUUIDAsDeviceId`](https://braze-inc.github.io/braze-swift-sdk/documentation/brazekit/braze/configuration-swift.class/useuuidasdeviceid).
   - This value determines whether the device ID will be assigned to a randomly generated UUID or, when set to `false`, the device's IDFV.
   - For more details, refer to [IDFV Collection](https://www.braze.com/docs/developer_guide/analytics/managing_data_collection#idfv-collection).
 
-# 3.0.0
+## 3.0.0
 
 ##### Breaking
 - This version requires [`13.1.0`](https://github.com/braze-inc/braze-react-native-sdk/releases/tag/13.1.0) of the Braze React Native SDK.
@@ -30,17 +41,17 @@
 - Updates the sample app to use [Expo SDK 51](https://expo.dev/changelog/2024/05-07-sdk-51).
   - There are no known breaking incompatibilities with the Braze Expo plugin or Braze React Native SDK.
 
-# 2.1.2
+## 2.1.2
 
 ##### Fixed
 - Fixes the sample app to contain examples on configuring app extension build settings for Expo Application Services (EAS).
 
-# 2.1.1
+## 2.1.1
 
 ##### Fixed
 - Tentative fix for code-signing notification extensions on iOS when using Expo Managed Workflow and Expo Application Services (EAS).
 
-# 2.1.0
+## 2.1.0
 
 ##### Added
 - Adds support for Rich Push notifications and Push Stories.
@@ -48,7 +59,7 @@
   - Set `enableBrazeIosPushStories` to `true` and configure your app group name with `iosPushStoryAppGroup` in your `app.json` to enable Push Stories.
   - For further integration details, refer to the native Swift SDK instructions for [Rich Push Notifications](https://braze-inc.github.io/braze-swift-sdk/tutorials/braze/b2-rich-push-notifications) and [Push Stories](https://braze-inc.github.io/braze-swift-sdk/tutorials/braze/b3-push-stories).
 
-# 2.0.0
+## 2.0.0
 
 ##### Breaking
 - Bumps the iOS minimum platform version to `13.4`, per the [Expo SDK 50 requirements](https://expo.dev/changelog/2024/01-18-sdk-50).
@@ -59,14 +70,14 @@
   - This release removes strict dependencies on Java 11 from the `build.gradle` file.
   - This fix adds namespacing and `buildFeatures.buildConfig` for compatibility with Android Gradle Plugin 8+.
 
-# 1.2.0
+## 1.2.0
 
 ##### Added
 - Updates the `enableBrazeIosPush` configuration to use the [automatic push handling](https://braze-inc.github.io/braze-swift-sdk/tutorials/braze/b1-standard-push-notifications#Option-1-Automatic-push-notification-handling) features from the Braze Swift SDK.
   - This release requires version [8.2.0+](https://github.com/braze-inc/braze-react-native-sdk/releases/tag/8.2.0) of the Braze React Native SDK, this change allows the Braze Expo plugin to be compatible with incoming iOS notifications from Expo Notifications.
 - Adds the `iosRequestPushPermissionsAutomatically` configuration to control whether iOS push permissions should be requested automatically on app launch.
 
-# 1.1.2
+## 1.1.2
 
 ##### Added
 - Added Android support for the following configuration fields:
@@ -81,12 +92,12 @@
 - Updated the sample app with version `6.0.1` of the the Braze React Native SDK.
   - This version demonstrates usage of the New Architecture and the Braze SDK as a Turbo Module.
 
-# 1.1.1
+## 1.1.1
 
 ##### Fixed
 - Fixed an issue where `Braze.getInitialUrl()` could incorrectly return `null`.
 
-# 1.1.0
+## 1.1.0
 
 ##### ⚠ Breaking
 - Now requires Braze React Native SDK v2.1.0+.
@@ -95,17 +106,17 @@
 ##### Changed
 - No longer requires static linkage of frameworks for iOS.
 
-# 1.0.1
+## 1.0.1
 
 ##### Fixed
 - Fixed an issue introduced in 1.0.0 where setting `enableAutoLocationCollection` to any value in `app.json` would enable the option on iOS.
 
-# 1.0.0
+## 1.0.0
 
 ##### ⚠ Breaking
 - Adds support for Braze React Native SDK v2.0.2+. This version is not backwards compatible with previous versions of Braze React Native SDK.
 
-# 0.6.0
+## 0.6.0
 
 ##### ⚠ Breaking
 - The Braze Expo Plugin now requires Expo 47.
@@ -114,12 +125,12 @@
 ##### Added
 - Added a new configuration prop `androidHandlePushDeepLinksAutomatically` that allows the Braze SDK to automatically handle push deep links on Android.
 
-# 0.5.0
+## 0.5.0
 
 ##### ⚠ Breaking
 - The iOS deployment target has been changed to 13.0 for compatibility with Expo 47.
 
-# 0.4.0
+## 0.4.0
 
 ##### ⚠ Breaking
 - Renamed the prop `fcmSenderID` to `firebaseCloudMessagingSenderId`.
@@ -127,21 +138,21 @@
 ##### Added
 - Added support for Android and iOS push.
 
-# 0.3.1
+## 0.3.1
 
 ##### Fixed
 - Fixed an issue where the `minimumTriggerIntervalInSeconds` prop did not work as expected on Android.
 
-# 0.3.0
+## 0.3.0
 
 ##### ⚠ Breaking
 - Renamed `customEndpoint` to `baseUrl`.
 
-# 0.2.0
+## 0.2.0
 
 ##### ⚠ Breaking
 - Removed the `apiKey` prop and replaced it with `iosApiKey` and `androidApiKey` parameters, both of which are required.
 
-# 0.1.0
+## 0.1.0
 
 - Initial release with support for in-app messages, content cards, and analytics.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ See [the Braze Developer Guide](https://www.braze.com/docs/developer_guide/sdk_i
 
 | Braze Expo Plugin | Braze React Native SDK |
 | ----------------- | ---------------------- |
+| >=4.0.0           | >= 19.0.0              |
 | >=3.0.0           | >= 13.1.0              |
 | >=2.0.0           | >= 8.3.0               |
 | >=1.1.0           | >= 2.1.0               |

--- a/example/app.json
+++ b/example/app.json
@@ -50,6 +50,8 @@
           "enableSdkAuthentication": true,
           "logLevel": 0,
           "enableGeofence": true,
+          "enableAutomaticLocationCollection": true,
+          "enableAutomaticGeofenceRequests": true,
           "dismissModalOnOutsideTap": true,
           "minimumTriggerIntervalInSeconds": 0,
           "enableBrazeIosPush": true,
@@ -63,6 +65,12 @@
           "androidNotificationAccentColor": "#ff112233",
           "iosUseUUIDAsDeviceId": true,
           "iosForwardUniversalLinks": false
+        }
+      ],
+      [
+        "expo-location",
+        {
+          "locationAlwaysAndWhenInUsePermission": "Allow $(PRODUCT_NAME) to use your location for tracking and geofences."
         }
       ]
     ],

--- a/example/assets/google-services.json
+++ b/example/assets/google-services.json
@@ -20,7 +20,7 @@
       ],
       "api_key": [
         {
-          "current_key": "AIzaSyDLN-hovjVZcVkcDC12VXaLscdakam694k"
+          "current_key": ""
         }
       ],
       "services": {

--- a/example/components/Braze.tsx
+++ b/example/components/Braze.tsx
@@ -14,6 +14,7 @@ import {
 import RadioGroup from 'react-native-radio-buttons-group';
 import Braze from '@braze/react-native-sdk';
 import * as Notifications from 'expo-notifications';
+import * as Location from 'expo-location';
 
 // Change to `true` to automatically log clicks, button clicks,
 // and impressions for in-app messages and content cards.
@@ -169,7 +170,7 @@ export const BrazeComponent = (): ReactElement => {
       })
       .catch(err => console.error('Error getting initial URL', err));
 
-    // Handles push notification payloads and deep links when an iOS app is launched from terminated state via push click.
+    // Handles push notification payloads and deep links when the app is launched from terminated state via push click.
     // For more detail, see `Braze.getInitialPushPayload`.
     Braze.getInitialPushPayload(pushPayload => {
       if (pushPayload) {
@@ -534,6 +535,11 @@ export const BrazeComponent = (): ReactElement => {
   const requestLocationInitialization = () => {
     Braze.requestLocationInitialization();
     showToast('Init Requested');
+  };
+
+  const requestLocationPermissions = () => {
+    Location.requestForegroundPermissionsAsync();
+    showToast('Location Permissions Requested');
   };
 
   // Note that this should normally be called only once per session
@@ -942,6 +948,9 @@ export const BrazeComponent = (): ReactElement => {
       ) : (
         false
       )}
+      <TouchableHighlight onPress={requestLocationPermissions}>
+        <Text>Request Location Permissions</Text>
+      </TouchableHighlight>
       <TouchableHighlight onPress={requestGeofences}>
         <Text>Request Geofences</Text>
       </TouchableHighlight>

--- a/example/package.json
+++ b/example/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@braze/expo-plugin": "file:../plugin",
-    "@braze/react-native-sdk": "^16.1.0",
+    "@braze/react-native-sdk": "^19.0.0",
     "@expo/metro-runtime": "^6.1.2",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.4.7",
@@ -28,6 +28,7 @@
     "expo-file-system": "^19.0.14",
     "expo-font": "~14.0.8",
     "expo-linking": "~8.0.8",
+    "expo-location": "~19.0.8",
     "expo-notifications": "~0.32.11",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
@@ -46,9 +47,9 @@
     "@babel/core": "^7.19.3",
     "@types/react": "^19.1.13",
     "@types/react-native": "~0.73.0",
+    "@types/react-test-renderer": "^19.1.0",
     "jest": "^29.2.1",
     "jest-expo": "^52.0.6",
-    "@types/react-test-renderer": "^19.1.0",
     "typescript": "^5.8.3"
   },
   "private": true

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -954,12 +954,12 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@braze/expo-plugin@file:../plugin":
-  version "3.1.0"
+  version "4.0.0"
 
-"@braze/react-native-sdk@^16.1.0":
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/@braze/react-native-sdk/-/react-native-sdk-16.1.0.tgz#d66c838a4eb38d2c5390d3dc4168767d7808a55a"
-  integrity sha512-IUoL+36KELKk4w6tlNdYjJ2fi0QBs2HT+yhYsupwfntvbbKPdSqlKrXU0e/xAyDv34qACcIxl2AYxeeD7Vhptg==
+"@braze/react-native-sdk@^19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/@braze/react-native-sdk/-/react-native-sdk-19.0.0.tgz#fbde2156cae6b30e4b0a06e10a37952a0d008e65"
+  integrity sha512-Q5Xv8c07ng93JX4Dd5Xj4omGV35xm1mVQUGJaSD+ZQiVE5gNhX16w8DeQDoKOyKLSf9EoaMjA0k2iiXH3Ta/9w==
 
 "@expo/cli@54.0.6":
   version "54.0.6"
@@ -3575,6 +3575,11 @@ expo-linking@~8.0.8:
   dependencies:
     expo-constants "~18.0.8"
     invariant "^2.2.4"
+
+expo-location@~19.0.8:
+  version "19.0.8"
+  resolved "https://registry.yarnpkg.com/expo-location/-/expo-location-19.0.8.tgz#1805393151b1286021c1ad36246b6fd095d09b55"
+  integrity sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==
 
 expo-modules-autolinking@3.0.11:
   version "3.0.11"

--- a/plugin/android/build.gradle
+++ b/plugin/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+  compileSdkVersion safeExtGet("compileSdkVersion", 36)
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
 
   // Apply these features only if the Android Gradle Plugin version is 7.0.0 or higher.
@@ -34,7 +34,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    targetSdkVersion safeExtGet("targetSdkVersion", 36)
     versionCode 1
     versionName '1.1.0'
   }

--- a/plugin/android/src/main/java/expo/modules/adapters/braze/BrazeReactActivityLifecycleListener.kt
+++ b/plugin/android/src/main/java/expo/modules/adapters/braze/BrazeReactActivityLifecycleListener.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import com.braze.reactbridge.BrazeReactUtils
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 class BrazeReactActivityLifecycleListener() : ReactActivityLifecycleListener {
@@ -11,6 +12,7 @@ class BrazeReactActivityLifecycleListener() : ReactActivityLifecycleListener {
     
     override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
         this.activity = activity
+        BrazeReactUtils.populateInitialPushPayloadFromIntent(activity.intent)
     }
 
     override fun onNewIntent(intent: Intent?): Boolean {

--- a/plugin/ios/ExpoAdapterBraze/BrazeAppDelegate.swift
+++ b/plugin/ios/ExpoAdapterBraze/BrazeAppDelegate.swift
@@ -52,7 +52,7 @@ public class BrazeAppDelegate: ExpoAppDelegateSubscriber {
         configuration.location.automaticLocationCollection = enableAutoLocationCollection
       }
 
-      if let enableAutoGeofenceRequests = plistConfig["EnableAutomaticLocationCollection"] as? Bool {
+      if let enableAutoGeofenceRequests = plistConfig["EnableAutomaticGeofenceRequests"] as? Bool {
         if configuration.location.brazeLocationProvider == nil {
           configuration.location.brazeLocationProvider = BrazeLocationProvider()
         }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braze/expo-plugin",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "Config plugin for @braze/react-native-sdk package",
   "main": "build/withBraze.js",
   "types": "build/withBraze.d.ts",

--- a/plugin/src/withBrazeiOS.ts
+++ b/plugin/src/withBrazeiOS.ts
@@ -57,7 +57,7 @@ const withBrazeInfoPlist: ConfigPlugin<ConfigProps> = (config, props) => {
       }
 
       if (props.enableAutomaticGeofenceRequests != null) {
-        config.modResults.Braze.EnableAutomaticLocationCollection = props.enableAutomaticGeofenceRequests;
+        config.modResults.Braze.EnableAutomaticGeofenceRequests = props.enableAutomaticGeofenceRequests;
       }
 
       if (props.dismissModalOnOutsideTap != null) {


### PR DESCRIPTION
## 4.0.0

##### Breaking 
- This version requires [`19.0.0`](https://github.com/braze-inc/braze-react-native-sdk/releases/tag/19.0.0) of the Braze React Native SDK.
  - (Android) Fixed a memory leak in the data persistence layer.
  - (Android) Adds support for Braze.getInitialPushPayload() to handle push notification deep links when the app is launched from a terminated state. This resolves an issue where deep links from push notifications were not handled on Android when the app was cold started.

##### Fixed
- Fixes the `enableAutomaticGeofenceRequests` configuration on iOS to be assigned to the correct property.
  - Previously, this `app.json` configuration would be ignored and only enabled when `enableAutomaticLocationCollection` was `true`.