### PR TITLE
feat: bump iOS minimum deployment target to 16.4

### DIFF
--- a/plugin/ios/ExpoAdapterBraze.podspec
+++ b/plugin/ios/ExpoAdapterBraze.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.platform       = :ios, '13.4'
+  s.platform       = :ios, '16.4'
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/expo/config-plugins.git' }
   s.static_framework = true


### PR DESCRIPTION
Required for Expo SDK 56 compatibility

BREAKING CHANGE:  iOS minimum deployment target is 16.4

https://expo.dev/changelog/sdk-56-beta#upgrade-an-existing-project