### PR TITLE
add type-safe config plugin helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ npx expo install @braze/expo-plugin
 }
 ```
 
+``` typescript
+// app.config.ts
+import withBraze from "@braze/expo-plugin/plugin";
+
+export default {
+  expo: {
+    plugins: [
+      withBraze({
+        enableBrazeIosPush: true,
+        enableFirebaseCloudMessaging: true,
+      }),
+    ],
+  },
+};
+```
+
 ``` shell
 npx expo prebuild
 ```

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -4,6 +4,17 @@
   "description": "Config plugin for @braze/react-native-sdk package",
   "main": "build/withBraze.js",
   "types": "build/withBraze.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/withBraze.d.ts",
+      "default": "./build/withBraze.js"
+    },
+    "./plugin": {
+      "types": "./build/plugin.d.ts",
+      "default": "./build/plugin.js"
+    },
+    "./package.json": "./package.json"
+  },
   "sideEffects": false,
   "repository": {
     "type": "git",

--- a/plugin/src/plugin.ts
+++ b/plugin/src/plugin.ts
@@ -1,0 +1,6 @@
+import type { StaticPlugin } from "@expo/config-types";
+import type { ConfigProps } from "./types";
+
+export default function withBraze(props: ConfigProps = {}): StaticPlugin<ConfigProps> {
+  return ["@braze/expo-plugin", props];
+}

--- a/plugin/src/withBraze.ts
+++ b/plugin/src/withBraze.ts
@@ -27,13 +27,10 @@ function warningForDeprecatedProps(props: ConfigProps | undefined) {
   );
 }
 
-const withBraze: ConfigPlugin<ConfigProps> = (config, _props) => {
-  const props: ConfigProps = _props ?? {};
+const withBraze: ConfigPlugin<ConfigProps> = (config, props = {}) => {
   warningForDeprecatedProps(props);
-
   config = withAndroidBrazeSdk(config, props);
   config = withIOSBrazeSdk(config, props);
-
   return config;
 };
 
@@ -43,4 +40,4 @@ export default createRunOncePlugin(
   withBraze,
   pkg.name,
   pkg.version
-);
+) as ConfigPlugin<ConfigProps>;


### PR DESCRIPTION
Adds a typed @braze/expo-plugin/plugin entrypoint for Expo SDK 56 style type-safe config plugin usage in app.config.ts. This preserves the existing @braze/expo-plugin entrypoint for app.json/static config usage, while adding a helper that returns the static plugin tuple with ConfigProps typing for autocomplete, JSDoc, and deprecation hints.